### PR TITLE
cmd: use stderr to print errors

### DIFF
--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/cycloidio/infrapolicy-resource/models"
@@ -12,7 +11,8 @@ import (
 func main() {
 	var req models.InRequest
 	if err := json.NewDecoder(os.Stdin).Decode(&req); err != nil {
-		log.Fatalf("Failed to read InRequest: %s", err)
+		fmt.Fprintf(os.Stderr, "unable to decode request: %v", err)
+		os.Exit(1)
 	}
 
 	out := []models.Version{
@@ -21,7 +21,7 @@ func main() {
 
 	output, err := json.Marshal(out)
 	if err != nil {
-		fmt.Printf("unable to marshal to output: %v\n", err)
+		fmt.Fprintf(os.Stderr, "unable to marshal output: %v", err)
 		os.Exit(1)
 	}
 	fmt.Println(string(output))

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -11,29 +11,29 @@ import (
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Println("expected output path as first arg")
+		fmt.Fprint(os.Stderr, "expected output path as first arg")
 		os.Exit(1)
 	}
 
 	var req models.InRequest
 	if err := json.NewDecoder(os.Stdin).Decode(&req); err != nil {
-		fmt.Println("unable to read stdin: %v\n", err)
+		fmt.Fprintf(os.Stderr, "unable to read stdin: %v", err)
 		os.Exit(1)
 	}
 
 	criticals, err := strconv.Atoi(req.Version.Criticals)
 	if err != nil {
-		fmt.Println("unable to get number of criticals check")
+		fmt.Fprintf(os.Stderr, "unable to get number of criticals check: %v", err)
 		os.Exit(1)
 	}
 	warnings, err := strconv.Atoi(req.Version.Warnings)
 	if err != nil {
-		fmt.Println("unable to get number of criticals check")
+		fmt.Fprintf(os.Stderr, "unable to get number of warnings check: %v", err)
 		os.Exit(1)
 	}
 
 	if criticals > 0 || warnings > 0 {
-		fmt.Println("critical or warning checks are present, check metadata of your resource for more information")
+		fmt.Fprint(os.Stderr, "critical or warning checks are present, check metadata of your resource for more information")
 		os.Exit(1)
 	}
 
@@ -44,7 +44,7 @@ func main() {
 
 	output, err := json.Marshal(resp)
 	if err != nil {
-		fmt.Printf("unable to marshal to output: %v\n", err)
+		fmt.Fprintf(os.Stderr, "unable to marshal to output: %v", err)
 		os.Exit(1)
 	}
 	fmt.Println(string(output))

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -58,28 +58,28 @@ func terracost(org, tfplan, apiURL string) ([]models.Metadata, error) {
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Println("expected path to sources as first argument")
+		fmt.Fprint(os.Stderr, "expected path to sources as first argument")
 		os.Exit(1)
 	}
 	sourceDir := os.Args[1]
 	if err := os.Chdir(sourceDir); err != nil {
-		fmt.Printf("unable to access source dir: %v\n", err)
+		fmt.Fprintf(os.Stderr, "unable to access source dir: %v", err)
 		os.Exit(1)
 	}
 
 	var req models.OutRequest
 	if err := json.NewDecoder(os.Stdin).Decode(&req); err != nil {
-		fmt.Printf("unable to read from stdin: %v\n", err)
+		fmt.Fprintf(os.Stderr, "unable to read from stdin: %v", err)
 		os.Exit(1)
 	}
 
 	if req.Source.Email == "" || req.Source.Password == "" {
-		fmt.Printf("email and password are required")
+		fmt.Fprint(os.Stderr, "email and password are required")
 		os.Exit(1)
 	}
 
 	if req.Source.Org == "" || req.Source.Env == "" || req.Source.Project == "" {
-		fmt.Printf("org, env and project are required")
+		fmt.Fprint(os.Stderr, "org, env and project are required")
 		os.Exit(1)
 	}
 
@@ -96,7 +96,7 @@ func main() {
 	}
 
 	if _, err := exec.Command("cy", loginArgs...).Output(); err != nil {
-		fmt.Printf("unable to login to Cycloid: %v\n", err)
+		fmt.Fprintf(os.Stderr, "unable to login to Cycloid: %v", err)
 		os.Exit(1)
 	}
 
@@ -119,13 +119,13 @@ func main() {
 
 	out, err := exec.Command("cy", validateArgs...).Output()
 	if err != nil {
-		fmt.Printf("unable to validate terraform plan: %v\n", err)
+		fmt.Fprintf(os.Stderr, "unable to validate terraform plan: %v", err)
 		os.Exit(1)
 	}
 
 	var res Result
 	if err := json.Unmarshal(out, &res); err != nil {
-		fmt.Printf("unable to unmarshal from cy output: %v\n", err)
+		fmt.Fprintf(os.Stderr, "unable to unmarshal from cy output: %v", err)
 		os.Exit(1)
 	}
 
@@ -174,7 +174,7 @@ func main() {
 	if req.Params.Terracost {
 		estimations, err := terracost(req.Source.Org, req.Params.TFPlanPath, req.Source.ApiURL)
 		if err != nil {
-			fmt.Printf("unable to run terracost check: %v\n", err)
+			fmt.Fprintf(os.Stderr, "unable to run terracost check: %v", err)
 			os.Exit(1)
 		}
 		metadatas = append(metadatas, estimations...)
@@ -188,7 +188,7 @@ func main() {
 
 	output, err := json.Marshal(resp)
 	if err != nil {
-		fmt.Printf("unable to marshal to output: %v\n", err)
+		fmt.Fprintf(os.Stderr, "unable to marshal to output: %v", err)
 		os.Exit(1)
 	}
 	fmt.Println(string(output))


### PR DESCRIPTION
in order to not be blind in pipeline context
