### PR TITLE
cmd/out: output@stderr the terracost JSON estimate for frontend parsing

### DIFF
--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -45,6 +45,9 @@ func terracost(org, tfplan, apiURL string) ([]models.Metadata, error) {
 		return nil, fmt.Errorf("unable to estimate terraform plan costs: %w\n", err)
 	}
 
+	// Output the terracost estimate JSON that will be used by the cycloid console
+	fmt.Fprintln(os.Stderr, string(out))
+
 	var res Estimation
 	if err := json.Unmarshal(out, &res); err != nil {
 		return nil, fmt.Errorf("unable to unmarshal from cy output: %w\n", err)


### PR DESCRIPTION
The ideal implementation would be to output it as metadata of the resource output.
The questions are:
- As the JSON can be quite big, how does Concourse will handle big metadata fields?
- Does it scale well?
- Does it take a lot of space in the DB?
- How big is the field in the DB, do we have a limit in size?

So the other, dirtier, solution (currently implemented in this PR) is to output the JSON on STDERR to show it as PUT logs which can then we parsed by the FE.